### PR TITLE
remove +1 day from timesteps

### DIFF
--- a/dryes/indices/dryes_index.py
+++ b/dryes/indices/dryes_index.py
@@ -256,7 +256,6 @@ class DRYESIndex:
         timesteps_to_iterate = set.union(*[set(timesteps_to_compute[agg_name]) for agg_name in agg_names])
         timesteps_to_iterate = list(timesteps_to_iterate)
         timesteps_to_iterate.sort()
-        breakpoint()
         if len(timesteps_to_iterate) > 0:
             self.log.info(f'Aggregating input data ({variable_in.name})...')
 
@@ -386,7 +385,7 @@ class DRYESIndex:
                     for time in ts_todo:
                         self.log.info(f'   {time:%d/%m/%Y}')
                         history = reference_fn(time)
-                        case['tags'].update({'history_start': history.start, 'history_end': history.end})
+                        case['tags'].update({'history_start': history.start, 'history_end': history.end})      
                         index_data = self.calc_index(time, history, case)
                         index.write_data(index_data, time = time)
 

--- a/workflow_examples/spi_run_direct.py
+++ b/workflow_examples/spi_run_direct.py
@@ -23,7 +23,7 @@ def main():
                         #"6"  : agg.sum_of_window(size = 6,  unit = 'months'),
                         #"12" : agg.sum_of_window(size = 12, unit = 'months')
                     },
-            "distribution" : {"gamma":"gamma", "normal":"normal", "pearson3":"pearson3"},
+            #"distribution" : {"gamma":"gamma", "normal":"normal", "pearson3":"pearson3"},
             #"pval_threshold" : {"t05": 0.05, "t10": 0.1},
             #"post_fn": {"Sigma2" : pp.gaussian_smoothing(sigma = 2),
             #            "Sigma4" : pp.gaussian_smoothing(sigma = 4)}
@@ -41,28 +41,28 @@ def main():
                                 file = 'gamma/loc/locAgg{agg_fn}_{history_start:%Y%m%d}-{history_end:%Y%m%d}_%m%d.tif'),
             'gamma.scale':   Local(name = 'gamma.scale (SPI)', path = PARAMS,
                                 file = 'gamma/scale/scaleAgg{agg_fn}_{history_start:%Y%m%d}-{history_end:%Y%m%d}_%m%d.tif'),
-            'normal.loc':    Local(name = 'normal.loc (SPI)',   path = PARAMS,
-                                file = 'normal/loc/locAgg{agg_fn}_{history_start:%Y%m%d}-{history_end:%Y%m%d}_%m%d.tif'),
-            'normal.scale':  Local(name = 'normal.scale (SPI)', path = PARAMS,
-                                file = 'normal/scale/scaleAgg{agg_fn}_{history_start:%Y%m%d}-{history_end:%Y%m%d}_%m%d.tif'),
-            'pearson3.skew': Local(name = 'pearson3.a (SPI)',     path = PARAMS,
-                                file = 'pearson3/skew/skewAgg{agg_fn}_{history_start:%Y%m%d}-{history_end:%Y%m%d}_%m%d.tif'),
-            'pearson3.loc':  Local(name = 'pearson3.loc (SPI)',   path = PARAMS,
-                                file = 'pearson3/loc/locAgg{agg_fn}_{history_start:%Y%m%d}-{history_end:%Y%m%d}_%m%d.tif'),
-            'pearson3.scale':Local(name = 'pearson3gamma.scale (SPI)', path = PARAMS,
-                                file = 'pearson3/scale/scaleAgg{agg_fn}_{history_start:%Y%m%d}-{history_end:%Y%m%d}_%m%d.tif'),
+            # 'normal.loc':    Local(name = 'normal.loc (SPI)',   path = PARAMS,
+            #                     file = 'normal/loc/locAgg{agg_fn}_{history_start:%Y%m%d}-{history_end:%Y%m%d}_%m%d.tif'),
+            # 'normal.scale':  Local(name = 'normal.scale (SPI)', path = PARAMS,
+            #                     file = 'normal/scale/scaleAgg{agg_fn}_{history_start:%Y%m%d}-{history_end:%Y%m%d}_%m%d.tif'),
+            # 'pearson3.skew': Local(name = 'pearson3.a (SPI)',     path = PARAMS,
+            #                     file = 'pearson3/skew/skewAgg{agg_fn}_{history_start:%Y%m%d}-{history_end:%Y%m%d}_%m%d.tif'),
+            # 'pearson3.loc':  Local(name = 'pearson3.loc (SPI)',   path = PARAMS,
+            #                     file = 'pearson3/loc/locAgg{agg_fn}_{history_start:%Y%m%d}-{history_end:%Y%m%d}_%m%d.tif'),
+            # 'pearson3.scale':Local(name = 'pearson3gamma.scale (SPI)', path = PARAMS,
+            #                     file = 'pearson3/scale/scaleAgg{agg_fn}_{history_start:%Y%m%d}-{history_end:%Y%m%d}_%m%d.tif'),
             'prob0':         Local(name = 'prob_0 (SPI)',      path = PARAMS,
                                 file = 'prob0/prob0Agg{agg_fn}_{history_start:%Y%m%d}-{history_end:%Y%m%d}_%m%d.tif'),
             
             # outputs
             'log'  : Local(name = 'log SPI', path = HOME, file =  'log.txt'),
             'index': Local(name = 'Standardised Precipitation Index (SPI)', 
-                        path = OUTPUT, file = 'SPI{agg_fn}{distribution}_%Y%m%d000000.tif')}
+                        path = OUTPUT, file = 'SPI{agg_fn}_%Y%m%d000000.tif')}
     )
 
     spi_mcm_ita.compute(current   = (datetime(2020,1,1), datetime(2020,12,31)),
-                        reference = (datetime(2010,1,1), datetime(2022,12,31)),
-                        timesteps_per_year = 12)
+                        reference = (datetime(2010,1,1), datetime(2019,12,31)),
+                        timesteps_per_year = 36)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Previously, we used end_of_timestep+1day for the naming convention of files. We have now removed the +1day for all internal processes. This significantly facilitates calculations. For all products that need to go onto dewetra, the changing of the filename will need to happen after DRYES.